### PR TITLE
Loosen RxSwift dependency to allow using RxSwift 3.1.0

### DIFF
--- a/RxMKMapView.podspec
+++ b/RxMKMapView.podspec
@@ -47,7 +47,7 @@ DESC
     'RxMKMapView' => ['Pod/Assets/*.png']
   }
 
-  s.dependency 'RxCocoa', '~> 3.0.0'
-  s.dependency 'RxSwift', '~> 3.0.0'
+  s.dependency 'RxCocoa', '~> 3.0'
+  s.dependency 'RxSwift', '~> 3.0'
   s.frameworks = 'Foundation'
 end


### PR DESCRIPTION
The dependency for RxSwift & RxCocoa is too strong (targeting Major, Minor and Build)
Loosening it to 3.0 would allow using RxSwift 3.1.0 as well :) 

This would solve https://github.com/RxSwiftCommunity/RxMKMapView/issues/17