### PR TITLE
Annotation binding

### DIFF
--- a/Example/Tests/RxMKMapViewTests.swift
+++ b/Example/Tests/RxMKMapViewTests.swift
@@ -362,4 +362,64 @@ class RxMKMapViewTests: XCTestCase {
         expect(resultView).to(equal(overlayRenders))
     }
     
+    func test_rx_annotationsArrayBinding() {
+        let mapView = MKMapView()
+        
+        let annotation1 = MKPointAnnotation()
+        annotation1.title = "title1"
+        annotation1.subtitle = "subtitle1"
+        
+        let annotation2 = MKPointAnnotation()
+        annotation2.title = "title2"
+        annotation2.subtitle = "subtitle2"
+        
+        let annotations = [annotation1, annotation2]
+        
+        _ = Observable.from(annotations)
+            .bindTo(mapView.rx.annotations)
+        
+        expect(mapView.annotations as? [MKPointAnnotation]).to(contain(annotations))
+    }
+    
+    func test_rx_annotationsBinding() {
+        let mapView = MKMapView()
+        
+        let annotation1 = MKPointAnnotation()
+        annotation1.title = "title1"
+        annotation1.subtitle = "subtitle1"
+        
+        let annotation2 = MKPointAnnotation()
+        annotation2.title = "title2"
+        annotation2.subtitle = "subtitle2"
+        
+        let annotations: [MKAnnotation] = [annotation1, annotation2]
+        
+         _ = Observable.of(annotations)
+            .bindTo(mapView.rx.annotations)
+        
+        let exp = self.expectation(description: "wait for annotation")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expect(mapView.annotations).to(haveCount(2))
+            exp.fulfill()
+        }
+        
+        waitForExpectations(timeout: 0.2, handler: nil)
+    }
+    
+    func test_rx_annotationsClosureBinding() {
+        let mapView = MKMapView()
+        
+        let titles: [String] = ["title1" , "title2"]
+        
+        _ = Observable.of(titles)
+            .bindTo(mapView.rx.annotations) { title in
+                let annotation = MKPointAnnotation()
+                annotation.title = title
+                return annotation
+            }
+        
+        expect(mapView.annotations).to(haveCount(2))
+    }
 }
+

--- a/Pod/Classes/MKMapView+Rx.swift
+++ b/Pod/Classes/MKMapView+Rx.swift
@@ -226,4 +226,36 @@ extension Reactive where Base : MKMapView {
             }
         return ControlEvent(events: source)
     }
+    
+    // MARK: Binding annotation to the Map
+    
+    public func annotations<S: Sequence, O: ObservableType> (_ source: O)
+        -> (_ transform: @escaping (S.Iterator.Element) -> MKAnnotation)
+        -> Disposable where O.E == S {
+            
+            return { factory in
+                source.map { elements -> [MKAnnotation] in
+                    elements.map(factory)
+                }
+                .bindTo(self.annotations)
+            }
+    }
+    
+    public func annotations<O: ObservableType> (_ source: O)
+        -> Disposable where O.E == [MKAnnotation] {
+        return source.subscribe(AnyObserver { event in
+            if case let .next(element) = event {
+                self.base.addAnnotations(element as! [MKAnnotation])
+            }
+        })
+    }
+    
+    public func annotations<O: ObservableType> (_ source: O)
+        -> Disposable where O.E: MKAnnotation {
+        return source.subscribe(AnyObserver { event in
+            if case let .next(element) = event {
+                self.base.addAnnotation(element)
+            }
+        })
+    }
 }

--- a/Pod/Classes/MKMapView+Rx.swift
+++ b/Pod/Classes/MKMapView+Rx.swift
@@ -245,7 +245,7 @@ extension Reactive where Base : MKMapView {
         -> Disposable where O.E == [MKAnnotation] {
         return source.subscribe(AnyObserver { event in
             if case let .next(element) = event {
-                self.base.addAnnotations(element as! [MKAnnotation])
+                self.base.addAnnotations(element)
             }
         })
     }


### PR DESCRIPTION
Hi!

This PR contains two function to allow annotation binding, you can do this:

- Bind an annotation array observable
```swift 
observableOfAnnotationArray.bindTo(mapView.rx.annotation)
```

- Bind an annotation observable
```swift 
observableOfAnnotation.bindTo(mapView.rx.annotation)
```

- Bind and observable of objects (for example a array of bus stops with coordinate information)
```swift
observableOfObjects
     .bindTo(mapView.rx.annotation) { busStop in
           let coordinates
                            = CLLocationCoordinate2D(latitude: stop.latitude, longitude: stop.longitude) 
           let annotation = MKPointAnnotation()
           annotation.coordinate = coordinates
           annotation.title = stop.address

           return annotation
     }
}
```