### PR TITLE
Add possibility to specify a view-builder for annotations when binding

### DIFF
--- a/Sources/MKMapView+Rx.swift
+++ b/Sources/MKMapView+Rx.swift
@@ -300,32 +300,32 @@ extension Reactive where Base: MKMapView {
             }
     }
 
-  // MARK: Binding overlay to the Map
-  public func overlays<
-    A: MKOverlay,
-    O: ObservableType>
-    (_ source: O)
-    -> Disposable
-    where O.Element == [A] {
-      return self.overlays(dataSource: RxMapViewReactiveOverlayDataSource())(source)
-  }
-  
-  public func overlays<
-    DataSource: RxMapViewDataSourceType,
-    O: ObservableType>
-    (dataSource: DataSource)
-    -> (_ source: O)
-    -> Disposable
-    where O.Element == [DataSource.Element],
-    DataSource.Element: MKOverlay {
-      return { source in
-        return source
-          .subscribe({ event in
-            dataSource.mapView(self.base, observedEvent: event)
-          })
-      }
-  }
-  
+    // MARK: Binding overlay to the Map
+    public func overlays<
+        A: MKOverlay,
+        O: ObservableType>
+        (_ source: O)
+        -> Disposable
+        where O.Element == [A] {
+            return self.overlays(dataSource: RxMapViewReactiveOverlayDataSource())(source)
+    }
+
+    public func overlays<
+        DataSource: RxMapViewDataSourceType,
+        O: ObservableType>
+        (dataSource: DataSource)
+        -> (_ source: O)
+        -> Disposable
+        where O.Element == [DataSource.Element],
+        DataSource.Element: MKOverlay {
+            return { source in
+                return source
+                    .subscribe({ event in
+                        dataSource.mapView(self.base, observedEvent: event)
+                    })
+            }
+    }
+
     /// Installs delegate as forwarding delegate on `delegate`.
     /// Delegate won't be retained.
     ///

--- a/Sources/RxMKMapViewDelegateProxy.swift
+++ b/Sources/RxMKMapViewDelegateProxy.swift
@@ -29,3 +29,19 @@ class RxMKMapViewDelegateProxy: DelegateProxy<MKMapView, MKMapViewDelegate>, Del
         self.register { RxMKMapViewDelegateProxy(mapView: $0) }
     }
 }
+
+class RxMapViewAnnotationViewBuilderDelegate<A: MKAnnotation>: NSObject, MKMapViewDelegate {
+    typealias AnnotationViewBuilder = (MKMapView, A) -> MKAnnotationView
+    private let annotationViewBuilder: AnnotationViewBuilder
+    init(annotationViewBuilder: @escaping AnnotationViewBuilder) {
+        self.annotationViewBuilder = annotationViewBuilder
+    }
+
+    func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        guard let typedAnnotation = annotation as? A else {
+            // Just let the system handle this
+            return nil
+        }
+        return annotationViewBuilder(mapView, typedAnnotation)
+    }
+}


### PR DESCRIPTION
This PR adds a new overload to `mapView.rx.annotations` that permit the caller to define how a annotation should be rendered in the map, giving a callsite like:

```
requestForAnnotations() // Observable<[MyMapAnnotation]>
              .asDriver(onErrorJustReturn: [])
              .drive(mapView.rx.annotations) { (mapView, annotation) in
                  return mapView.dequeueReusableAnnotationView(withIdentifier: "MyMapAnnotationView", for: annotation)
              }
              .disposed(by: disposeBag)
```

This is a nicer solution to #12, at least in my opinion