### PR TITLE
Fix after release iOS 16 new methods for mapView/didSelect/didDeselect

### DIFF
--- a/Sources/MKMapView+Rx.swift
+++ b/Sources/MKMapView+Rx.swift
@@ -199,8 +199,12 @@ extension Reactive where Base: MKMapView {
     // MARK: Selecting Annotation Views
 
     public var didSelectAnnotationView: ControlEvent<MKAnnotationView> {
+        let selector = #selector(
+            (MKMapViewDelegate.mapView(_:didSelect:))
+            as (MKMapViewDelegate) -> ((MKMapView, MKAnnotationView) -> Void)?
+        )
         let source = delegate
-            .methodInvoked(#selector(MKMapViewDelegate.mapView(_:didSelect:)))
+            .methodInvoked(selector)
             .map { a in
                 return try castOrThrow(MKAnnotationView.self, a[1])
             }
@@ -208,8 +212,13 @@ extension Reactive where Base: MKMapView {
     }
 
     public var didDeselectAnnotationView: ControlEvent<MKAnnotationView> {
+        let selector = #selector(
+            (MKMapViewDelegate.mapView(_:didDeselect:))
+            as (MKMapViewDelegate) -> ((MKMapView, MKAnnotationView) -> Void)?
+        )
+        
         let source = delegate
-            .methodInvoked(#selector(MKMapViewDelegate.mapView(_:didDeselect:)))
+            .methodInvoked(selector)
             .map { a in
                 return try castOrThrow(MKAnnotationView.self, a[1])
             }


### PR DESCRIPTION
During the release of iOS 16, the API was extended with new functionality for MapViewDelegate (https://developer.apple.com/documentation/mapkit/mkmapviewdelegate?language=objc).
Mainly about the `didSelect` and `didDeselect` methods.

Selecting annotations and annotations views
func mapView(MKMapView, didSelect: MKAnnotationView)
Tells the delegate when the user selects one or more of its annotation views.
func mapView(MKMapView, didDeselect: MKAnnotationView)
Tells the delegate when the user selects one or more of its annotation views.
func mapView(MKMapView, didDeselect: any MKAnnotation)
Tells the delegate when the user selects one or more annotations.
func mapView(MKMapView, didSelect: any MKAnnotation)
Tells the delegate when the user selects one or more annotations.

As you can see, you must always type as included in the PR I am sending.